### PR TITLE
Fix compilation with GCC 7.1.0

### DIFF
--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -235,7 +235,7 @@ RFILE *filestream_open(const char *path, unsigned mode, ssize_t len)
 #endif
    {
       /* FIXME: HAVE_BUFFERED_IO is always 1, but if it is ever changed, open() needs to be changed to _wopen() for WIndows. */
-      stream->fd = open(path, flags);
+      stream->fd = open(path, flags, mode_int);
       if (stream->fd == -1)
          goto error;
 #ifdef HAVE_MMAP


### PR DESCRIPTION
Building with GCC 7.1.0 requires the mode to be added as argument to the open function.